### PR TITLE
Update Kafka deployment to use fatal69100/kafka:2.8.1 image

### DIFF
--- a/broker/kafka.yaml
+++ b/broker/kafka.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: kafka
-        image: wurstmeister/kafka
+        image: fatal69100/kafka:2.8.1
         ports:
           - containerPort: 9092
         resources: {}
@@ -29,15 +29,13 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
           - name: KAFKA_ADVERTISED_PORT
-            value: 9092
+            value: '9092'
           - name: KAFKA_ZOOKEEPER_CONNECT
             value: zookeeper:2181
-          - name: KAFKA_ADVERTISED_PORT
-            value: 9092
           - name: KAFKA_ADVERTISED_HOST_NAME
             value: $(MY_POD_IP)
           - name: KAFKA_PORT
-            value: "9092"
+            value: '9092'
       hostname: kafka
       restartPolicy: Always
       serviceAccountName: ""


### PR DESCRIPTION
Changes Made:
- Updated image field in the Kafka deployment to fatal69100/kafka:2.8.1
- Adjusted environment variable values to ensure proper configuration and consistency wq